### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ cy
   .mhGetAllMails()
   .mhFirst()
   .mhGetSender()
-  .should('be', 'sender@example.com');
+  .should('eq', 'sender@example.com');
 ``` 
 #### mhGetRecipients()
 Yields the sender of the current mail.


### PR DESCRIPTION
Fix CypressError "The chainer be is a language chainer provided to improve the readability of your assertions, not an actual assertion. Please provide a valid assertion"