### PR TITLE
Add auth option and configurable limit param

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,31 +23,38 @@ Add the base url of your MailHog installation to your `cypress.json`:
 }
 ```
 
+If your Mailhog instance uses authentication, add `mailHogAuth` to your cypress `env` config:
+```json
+{
+  ...
+  "mailHogAuth": {"user": "mailhog username", "pass": "mailhog password"}
+}
+
 
 ## Commands
 ### Mail Collection
-#### mhGetAllMails() 
+#### mhGetAllMails(limit=50) 
 Yields an array of all the mails stored in MailHog.
 ```JavaScript
 cy
   .mhGetAllMails()
   .should('have.length', 1);
 ```
-#### mhGetMailsBySubject( subject ) 
+#### mhGetMailsBySubject( subject, limit=50 ) 
 Yields an array of all mails with given subject.
 ```JavaScript
 cy
   .mhGetMailsBySubject('My Subject')
   .should('have.length', 1);
 ```
-#### mhGetMailsBySender( from ) 
+#### mhGetMailsBySender( from, limit=50) 
 Yields an array of all mails with given sender.
 ```JavaScript
 cy
   .mhGetMailsBySender('sender@example.com')
   .should('have.length', 1);
 ```
-#### mhGetMailsByRecipient( recipient ) 
+#### mhGetMailsByRecipient( recipient, limit=50 ) 
 Yields an array of all mails with given recipient.
 ```JavaScript
 cy

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If your Mailhog instance uses authentication, add `mailHogAuth` to your cypress 
   ...
   "mailHogAuth": {"user": "mailhog username", "pass": "mailhog password"}
 }
-
+```
 
 ## Commands
 ### Mail Collection

--- a/index.js
+++ b/index.js
@@ -63,14 +63,14 @@ Cypress.Commands.add('mhFirst', {prevSubject: true}, (mails) => {
   return Array.isArray(mails) && mails.length > 0 ? mails[0] : mails;
 });
 
-Cypress.Commands.add('mhGetMailsBySubject', (subject) => {
-  cy.mhGetAllMails().then((mails) => {
+Cypress.Commands.add('mhGetMailsBySubject', (subject, auth=auth_default, limit=50) => {
+  cy.mhGetAllMails(auth, limit).then((mails) => {
     return mails.filter((mail) => mail.Content.Headers.Subject[0] === subject);
   });
 });
 
-Cypress.Commands.add('mhGetMailsByRecipient', (recipient) => {
-  cy.mhGetAllMails().then((mails) => {
+Cypress.Commands.add('mhGetMailsByRecipient', (recipient, auth=auth_default, limit=50) => {
+  cy.mhGetAllMails(auth, limit).then((mails) => {
     return mails.filter((mail) =>
       mail.To.map(
         (recipientObj) => `${recipientObj.Mailbox}@${recipientObj.Domain}`
@@ -79,8 +79,8 @@ Cypress.Commands.add('mhGetMailsByRecipient', (recipient) => {
   });
 });
 
-Cypress.Commands.add('mhGetMailsBySender', (from) => {
-  cy.mhGetAllMails().then((mails) => {
+Cypress.Commands.add('mhGetMailsBySender', (from, auth=auth_default, limit=50) => {
+  cy.mhGetAllMails(auth, limit).then((mails) => {
     return mails.filter((mail) => mail.Raw.From === from);
   });
 });

--- a/index.js
+++ b/index.js
@@ -6,45 +6,45 @@ const mhApiUrl = (path) => {
 
 const mhAuth = Cypress.env('mailHogAuth') || ''
 
-Cypress.Commands.add('mhGetJimMode', (auth=mhAuth) => {
+Cypress.Commands.add('mhGetJimMode', () => {
   return cy
     .request({
       method: 'GET',
       url: mhApiUrl('/v2/jim'),
       failOnStatusCode: false,
-      auth: auth
+      auth: mhAuth
     })
     .then((response) => {
       return cy.wrap(response.status === 200);
     });
 });
 
-Cypress.Commands.add('mhSetJimMode', (enabled, auth=mhAuth) => {
+Cypress.Commands.add('mhSetJimMode', (enabled) => {
   return cy.request({
     method: enabled ? 'POST' : 'DELETE',
     url: mhApiUrl('/v2/jim'),
     failOnStatusCode: false,
-    auth: auth
+    auth: mhAuth
   });
 });
 
 /**
  * Mail Collection
  */
-Cypress.Commands.add('mhDeleteAll', (auth=mhAuth) => {
+Cypress.Commands.add('mhDeleteAll', () => {
   return cy.request({
     method: 'DELETE',
     url: mhApiUrl('/v1/messages'),
-    auth: auth
+    auth: mhAuth
   })
 })
 
-Cypress.Commands.add('mhGetAllMails', (auth=mhAuth, limit=50) => {
+Cypress.Commands.add('mhGetAllMails', (limit=50) => {
   return cy
     .request({
       method: 'GET',
       url: mhApiUrl(`/v2/messages?limit=${limit}`),
-      auth: auth
+      auth: mhAuth
     })
     .then((response) => {
         if (typeof response.body === 'string') {
@@ -60,14 +60,14 @@ Cypress.Commands.add('mhFirst', {prevSubject: true}, (mails) => {
   return Array.isArray(mails) && mails.length > 0 ? mails[0] : mails;
 });
 
-Cypress.Commands.add('mhGetMailsBySubject', (subject, auth=mhAuth, limit=50) => {
-  cy.mhGetAllMails(auth, limit).then((mails) => {
+Cypress.Commands.add('mhGetMailsBySubject', (subject, limit=50) => {
+  cy.mhGetAllMails(limit).then((mails) => {
     return mails.filter((mail) => mail.Content.Headers.Subject[0] === subject);
   });
 });
 
-Cypress.Commands.add('mhGetMailsByRecipient', (recipient, auth=mhAuth, limit=50) => {
-  cy.mhGetAllMails(auth, limit).then((mails) => {
+Cypress.Commands.add('mhGetMailsByRecipient', (recipient, limit=50) => {
+  cy.mhGetAllMails(limit).then((mails) => {
     return mails.filter((mail) =>
       mail.To.map(
         (recipientObj) => `${recipientObj.Mailbox}@${recipientObj.Domain}`
@@ -76,8 +76,8 @@ Cypress.Commands.add('mhGetMailsByRecipient', (recipient, auth=mhAuth, limit=50)
   });
 });
 
-Cypress.Commands.add('mhGetMailsBySender', (from, auth=mhAuth, limit=50) => {
-  cy.mhGetAllMails(auth, limit).then((mails) => {
+Cypress.Commands.add('mhGetMailsBySender', (from, limit=50) => {
+  cy.mhGetAllMails(limit).then((mails) => {
     return mails.filter((mail) => mail.Raw.From === from);
   });
 });

--- a/index.js
+++ b/index.js
@@ -4,9 +4,10 @@ const mhApiUrl = (path) => {
   return `${basePath}/api${path}`;
 };
 
-const auth_default = {
-  "user": "",
-  "pass": ""
+const mhAuth = Cypress.env('mailHogAuth') = (auth) => {
+  if(auth == undefined) {
+    return {"user": "", "pass": ""}
+  }
 }
 
 Cypress.Commands.add('mhGetJimMode', (auth=auth_default) => {

--- a/index.js
+++ b/index.js
@@ -42,11 +42,11 @@ Cypress.Commands.add('mhDeleteAll', (auth=auth_default) => {
   })
 })
 
-Cypress.Commands.add('mhGetAllMails', (auth=auth_default) => {
+Cypress.Commands.add('mhGetAllMails', (auth=auth_default, limit=50) => {
   return cy
     .request({
       method: 'GET',
-      url: mhApiUrl('/v2/messages?limit=9999'),
+      url: mhApiUrl(`/v2/messages?limit=${limit}`),
       auth: auth
     })
     .then((response) => {

--- a/index.js
+++ b/index.js
@@ -4,38 +4,50 @@ const mhApiUrl = (path) => {
   return `${basePath}/api${path}`;
 };
 
-Cypress.Commands.add('mhGetJimMode', (enabled) => {
+const auth_default = {
+  "user": "",
+  "pass": ""
+}
+
+Cypress.Commands.add('mhGetJimMode', (auth=auth_default) => {
   return cy
     .request({
       method: 'GET',
       url: mhApiUrl('/v2/jim'),
       failOnStatusCode: false,
+      auth: auth
     })
     .then((response) => {
       return cy.wrap(response.status === 200);
     });
 });
 
-Cypress.Commands.add('mhSetJimMode', (enabled) => {
+Cypress.Commands.add('mhSetJimMode', (enabled, auth=auth_default) => {
   return cy.request({
     method: enabled ? 'POST' : 'DELETE',
     url: mhApiUrl('/v2/jim'),
     failOnStatusCode: false,
+    auth: auth
   });
 });
 
 /**
  * Mail Collection
  */
-Cypress.Commands.add('mhDeleteAll', () => {
-  return cy.request('DELETE', mhApiUrl('/v1/messages'));
-});
+Cypress.Commands.add('mhDeleteAll', (auth=auth_default) => {
+  return cy.request({
+    method: 'DELETE',
+    url: mhApiUrl('/v1/messages'),
+    auth: auth
+  })
+})
 
-Cypress.Commands.add('mhGetAllMails', () => {
+Cypress.Commands.add('mhGetAllMails', (auth=auth_default) => {
   return cy
     .request({
       method: 'GET',
       url: mhApiUrl('/v2/messages?limit=9999'),
+      auth: auth
     })
     .then((response) => {
         if (typeof response.body === 'string') {

--- a/index.js
+++ b/index.js
@@ -4,13 +4,9 @@ const mhApiUrl = (path) => {
   return `${basePath}/api${path}`;
 };
 
-const mhAuth = Cypress.env('mailHogAuth') = (auth) => {
-  if(auth == undefined) {
-    return {"user": "", "pass": ""}
-  }
-}
+const mhAuth = Cypress.env('mailHogAuth') || ''
 
-Cypress.Commands.add('mhGetJimMode', (auth=auth_default) => {
+Cypress.Commands.add('mhGetJimMode', (auth=mhAuth) => {
   return cy
     .request({
       method: 'GET',
@@ -23,7 +19,7 @@ Cypress.Commands.add('mhGetJimMode', (auth=auth_default) => {
     });
 });
 
-Cypress.Commands.add('mhSetJimMode', (enabled, auth=auth_default) => {
+Cypress.Commands.add('mhSetJimMode', (enabled, auth=mhAuth) => {
   return cy.request({
     method: enabled ? 'POST' : 'DELETE',
     url: mhApiUrl('/v2/jim'),
@@ -35,7 +31,7 @@ Cypress.Commands.add('mhSetJimMode', (enabled, auth=auth_default) => {
 /**
  * Mail Collection
  */
-Cypress.Commands.add('mhDeleteAll', (auth=auth_default) => {
+Cypress.Commands.add('mhDeleteAll', (auth=mhAuth) => {
   return cy.request({
     method: 'DELETE',
     url: mhApiUrl('/v1/messages'),
@@ -43,7 +39,7 @@ Cypress.Commands.add('mhDeleteAll', (auth=auth_default) => {
   })
 })
 
-Cypress.Commands.add('mhGetAllMails', (auth=auth_default, limit=50) => {
+Cypress.Commands.add('mhGetAllMails', (auth=mhAuth, limit=50) => {
   return cy
     .request({
       method: 'GET',
@@ -64,13 +60,13 @@ Cypress.Commands.add('mhFirst', {prevSubject: true}, (mails) => {
   return Array.isArray(mails) && mails.length > 0 ? mails[0] : mails;
 });
 
-Cypress.Commands.add('mhGetMailsBySubject', (subject, auth=auth_default, limit=50) => {
+Cypress.Commands.add('mhGetMailsBySubject', (subject, auth=mhAuth, limit=50) => {
   cy.mhGetAllMails(auth, limit).then((mails) => {
     return mails.filter((mail) => mail.Content.Headers.Subject[0] === subject);
   });
 });
 
-Cypress.Commands.add('mhGetMailsByRecipient', (recipient, auth=auth_default, limit=50) => {
+Cypress.Commands.add('mhGetMailsByRecipient', (recipient, auth=mhAuth, limit=50) => {
   cy.mhGetAllMails(auth, limit).then((mails) => {
     return mails.filter((mail) =>
       mail.To.map(
@@ -80,7 +76,7 @@ Cypress.Commands.add('mhGetMailsByRecipient', (recipient, auth=auth_default, lim
   });
 });
 
-Cypress.Commands.add('mhGetMailsBySender', (from, auth=auth_default, limit=50) => {
+Cypress.Commands.add('mhGetMailsBySender', (from, auth=mhAuth, limit=50) => {
   cy.mhGetAllMails(auth, limit).then((mails) => {
     return mails.filter((mail) => mail.Raw.From === from);
   });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,13 +1,13 @@
 declare namespace Cypress {
   interface Chainable {
-    mhGetJimMode(auth?: JSON): Chainable<boolean>;
-    mhSetJimMode(enabled : boolean, auth?: JSON): Chainable<Cypress.Response<any>>;
-    mhDeleteAll(auth?: JSON): Chainable<Cypress.Response<any>>;
-    mhGetAllMails(auth?: JSON, limit?: number): Chainable<mailhog.Item[]>;
+    mhGetJimMode(auth?: any): Chainable<boolean>;
+    mhSetJimMode(enabled : boolean, auth?: any): Chainable<Cypress.Response<any>>;
+    mhDeleteAll(auth?: any): Chainable<Cypress.Response<any>>;
+    mhGetAllMails(auth?: any, limit?: number): Chainable<mailhog.Item[]>;
     mhFirst(): Chainable<mailhog.Item>;
-    mhGetMailsBySubject(subject : string, auth?: JSON, limit?: number): Chainable<mailhog.Item[]>;
-    mhGetMailsByRecipient(recipient : string, auth?: JSON, limit?: number): Chainable<mailhog.Item[]>;
-    mhGetMailsBySender(from : string, auth?: JSON, limit?: number): Chainable<mailhog.Item[]>;
+    mhGetMailsBySubject(subject : string, auth?: any, limit?: number): Chainable<mailhog.Item[]>;
+    mhGetMailsByRecipient(recipient : string, auth?: any, limit?: number): Chainable<mailhog.Item[]>;
+    mhGetMailsBySender(from : string, auth?: any, limit?: number): Chainable<mailhog.Item[]>;
     mhGetSubject(): Chainable<string>;
     mhGetBody(): Chainable<string>;
     mhGetSender(): Chainable<string>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,11 +5,11 @@ declare namespace Cypress {
     mhDeleteAll(auth?: JSON): Chainable<Cypress.Response<any>>;
     mhGetAllMails(auth?: JSON, limit?: number): Chainable<mailhog.Item[]>;
     mhFirst(): Chainable<mailhog.Item>;
-    mhGetMailsBySubject(subject : string): Chainable<mailhog.Item[]>;
-    mhGetMailsByRecipient(recipient : string): Chainable<mailhog.Item[]>;
-    mhGetMailsBySender(from : string): Chainable<mailhog.Item[]>;
+    mhGetMailsBySubject(subject : string, auth?: JSON, limit?: number): Chainable<mailhog.Item[]>;
+    mhGetMailsByRecipient(recipient : string, auth?: JSON, limit?: number): Chainable<mailhog.Item[]>;
+    mhGetMailsBySender(from : string, auth?: JSON, limit?: number): Chainable<mailhog.Item[]>;
     mhGetSubject(): Chainable<string>;
-    mhGetBody(): Chainablce<string>;
+    mhGetBody(): Chainable<string>;
     mhGetSender(): Chainable<string>;
     mhGetRecipients(): Chainable<string[]>;
     mhHasMailWithSubject(subject : string): Chainable;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,7 @@
 declare namespace Cypress {
   interface Chainable {
-    mhGetJimMode(): Chainable<boolean>;
-    mhSetJimMode(enabled : boolean): Chainable<Cypress.Response<any>>;
+    mhGetJimMode(auth: JSON): Chainable<boolean>;
+    mhSetJimMode(enabled : boolean, auth: JSON): Chainable<Cypress.Response<any>>;
     mhDeleteAll(): Chainable<Cypress.Response<any>>;
     mhGetAllMails(): Chainable<mailhog.Item[]>;
     mhFirst(): Chainable<mailhog.Item>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,15 +1,15 @@
 declare namespace Cypress {
   interface Chainable {
-    mhGetJimMode(auth: JSON): Chainable<boolean>;
-    mhSetJimMode(enabled : boolean, auth: JSON): Chainable<Cypress.Response<any>>;
-    mhDeleteAll(): Chainable<Cypress.Response<any>>;
-    mhGetAllMails(): Chainable<mailhog.Item[]>;
+    mhGetJimMode(auth?: JSON): Chainable<boolean>;
+    mhSetJimMode(enabled : boolean, auth?: JSON): Chainable<Cypress.Response<any>>;
+    mhDeleteAll(auth?: JSON): Chainable<Cypress.Response<any>>;
+    mhGetAllMails(auth?: JSON, limit?: number): Chainable<mailhog.Item[]>;
     mhFirst(): Chainable<mailhog.Item>;
     mhGetMailsBySubject(subject : string): Chainable<mailhog.Item[]>;
     mhGetMailsByRecipient(recipient : string): Chainable<mailhog.Item[]>;
     mhGetMailsBySender(from : string): Chainable<mailhog.Item[]>;
     mhGetSubject(): Chainable<string>;
-    mhGetBody(): Chainable<string>;
+    mhGetBody(): Chainablce<string>;
     mhGetSender(): Chainable<string>;
     mhGetRecipients(): Chainable<string[]>;
     mhHasMailWithSubject(subject : string): Chainable;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,13 +1,13 @@
 declare namespace Cypress {
   interface Chainable {
-    mhGetJimMode(auth?: any): Chainable<boolean>;
-    mhSetJimMode(enabled : boolean, auth?: any): Chainable<Cypress.Response<any>>;
-    mhDeleteAll(auth?: any): Chainable<Cypress.Response<any>>;
-    mhGetAllMails(auth?: any, limit?: number): Chainable<mailhog.Item[]>;
+    mhGetJimMode(): Chainable<boolean>;
+    mhSetJimMode(enabled: boolean): Chainable<Cypress.Response<any>>;
+    mhDeleteAll(): Chainable<Cypress.Response<any>>;
+    mhGetAllMails(limit?: number): Chainable<mailhog.Item[]>;
     mhFirst(): Chainable<mailhog.Item>;
-    mhGetMailsBySubject(subject : string, auth?: any, limit?: number): Chainable<mailhog.Item[]>;
-    mhGetMailsByRecipient(recipient : string, auth?: any, limit?: number): Chainable<mailhog.Item[]>;
-    mhGetMailsBySender(from : string, auth?: any, limit?: number): Chainable<mailhog.Item[]>;
+    mhGetMailsBySubject(subject: string, limit?: number): Chainable<mailhog.Item[]>;
+    mhGetMailsByRecipient(recipient: string, limit?: number): Chainable<mailhog.Item[]>;
+    mhGetMailsBySender(from: string, limit?: number): Chainable<mailhog.Item[]>;
     mhGetSubject(): Chainable<string>;
     mhGetBody(): Chainable<string>;
     mhGetSender(): Chainable<string>;


### PR DESCRIPTION
This PR adds the following:

- Basic authentication via the `mailHogAuth` Cypress env var. This takes a JSON object with `user` and `pass` keys along with their respective values. Example can be found in the README (more info on auth handling here: https://github.com/request/request#http-authentication)
- An optional `limit` argument for `mhGetAllMails()`, `mhGetMailsBySubject()`, `mhGetMailsByRecipient()`, and `mhGetMailsBySender()` mail collection commands. I found the static limit of `9999` to slow down calls if you have a lot of emails sitting in your inbox. Setting a smaller limit helps speed up requests

These features helped streamline my usage of this package and I'm hoping others can benefit from them, too!