### PR TITLE
fix: support cypress ^10.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,15 @@ This package supports TypeScript out of the box.
 ### Setup
 Install this package via NPM:
 ```bash
-npm install --dev cypress-mailhog
+npm install cypress-mailhog
 ```
 
 Include this package into your Cypress command file:
 ```JavaScript
-// cypress/support/commands.js
+// cypress/support/commands
 import 'cypress-mailhog';
 ```
+###### Before cypress 10.0.0
 
 Add the base url of your MailHog installation to your `cypress.json`:
 ```json
@@ -21,6 +22,18 @@ Add the base url of your MailHog installation to your `cypress.json`:
   ...
   "mailHogUrl": "http://localhost:8090"
 }
+```
+
+###### After cypress 10.0.0
+
+Add the base url of your MailHog installation, add `mailHogUrl` to your cypress e2e config:
+```typescript
+export default defineConfig({
+    projectId: "****",
+    env: { 
+        mailHogUrl: "http://localhost:8090/",
+    }
+})
 ```
 
 If your Mailhog instance uses authentication, add `mailHogAuth` to your cypress `env` config:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-mailhog",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Cypress Commands for MailHog 🌳🐗",
   "main": "index.js",
   "types": "types/index.d.ts",


### PR DESCRIPTION
Remove support for cypress.json file, it has been removed in cypress 10.0.0.

Closes https://github.com/SMenigat/cypress-mailhog/issues/34