### PR TITLE
Add retry-ability to query commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,21 +46,21 @@ If your Mailhog instance uses authentication, add `mailHogAuth` to your cypress 
 
 ## Commands
 ### Mail Collection
-#### mhGetAllMails(limit=50) 
+#### mhGetAllMails( limit=50, options={timeout=defaultCommandTimeout} ) 
 Yields an array of all the mails stored in MailHog.
 ```JavaScript
 cy
   .mhGetAllMails()
   .should('have.length', 1);
 ```
-#### mhGetMailsBySubject( subject, limit=50 ) 
+#### mhGetMailsBySubject( subject, limit=50, options={timeout=defaultCommandTimeout} ) 
 Yields an array of all mails with given subject.
 ```JavaScript
 cy
   .mhGetMailsBySubject('My Subject')
   .should('have.length', 1);
 ```
-#### mhGetMailsBySender( from, limit=50) 
+#### mhGetMailsBySender( from, limit=50, options={timeout=defaultCommandTimeout} ) 
 Yields an array of all mails with given sender.
 ```JavaScript
 cy
@@ -79,6 +79,7 @@ Yields the first mail of the loaded selection.
 ```JavaScript
 cy
   .mhGetAllMails()
+  .should('have.length', 1)
   .mhFirst();
 ``` 
 #### mhDeleteAll()
@@ -94,6 +95,7 @@ Yields the subject of the current mail.
 ```JavaScript
 cy
   .mhGetAllMails()
+  .should('have.length', 1)  
   .mhFirst()
   .mhGetSubject()
   .should('eq', 'My Mails Subject');
@@ -103,6 +105,7 @@ Yields the body of the current mail.
 ```JavaScript
 cy
   .mhGetAllMails()
+  .should('have.length', 1)
   .mhFirst()
   .mhGetBody()
   .should('contain', 'Part of the Message Body');
@@ -112,6 +115,7 @@ Yields the sender of the current mail.
 ```JavaScript
 cy
   .mhGetAllMails()
+  .should('have.length', 1)
   .mhFirst()
   .mhGetSender()
   .should('eq', 'sender@example.com');
@@ -121,6 +125,7 @@ Yields the recipient of the current mail.
 ```JavaScript
 cy
   .mhGetAllMails()
+  .should('have.length', 1)
   .mhFirst()
   .mhGetRecipients()
   .should('contain', 'recipient@example.com');

--- a/test-server/cypress/integration/MailHog.ts
+++ b/test-server/cypress/integration/MailHog.ts
@@ -1,10 +1,10 @@
 const triggerAction = (actionName: string) => {
   return cy
     .get(`[data-action="${actionName}"`)
-    .click()
-    .get('.status-wrapper .status')
-    .contains('✅');
+    .click();
 };
+
+const simulatedTransportDelay = 250;
 
 describe('MailHog', () => {
   before(() => {
@@ -21,6 +21,7 @@ describe('MailHog', () => {
   });
   describe('Mail Collection', () => {
     beforeEach(() => {
+      cy.wait(simulatedTransportDelay); // make sure to wait for delayed messages before cleaning up
       cy.mhDeleteAll();
       triggerAction('generate-bulk');
     });
@@ -40,6 +41,7 @@ describe('MailHog', () => {
     });
     it('cy.mhDeleteAll() - delets all mails from MailCatcher', () => {
       cy
+        .wait(simulatedTransportDelay) // make sure to wait for delayed messages before cleaning up
         .mhDeleteAll()
         .mhGetAllMails()
         .should('have.length', 0);
@@ -47,12 +49,14 @@ describe('MailHog', () => {
   });
   describe('Handling a Single Mail ✉️', () => {
     beforeEach(() => {
+      cy.wait(simulatedTransportDelay); // make sure to wait for delayed messages before cleaning up
       cy.mhDeleteAll();
       triggerAction('generate-single');
     });
     it('mail.mhGetSubject() - returns the mails subject', () => {
       cy
         .mhGetAllMails()
+        .should('have.length', 1)
         .mhFirst()
         .mhGetSubject()
         .should('eq', 'Single Mail');
@@ -60,6 +64,7 @@ describe('MailHog', () => {
     it('mail.mhGetBody() - returns the message body', () => {
       cy
         .mhGetAllMails()
+        .should('have.length', 1)
         .mhFirst()
         .mhGetBody()
         .should('contain', 'HTML message body');
@@ -67,6 +72,7 @@ describe('MailHog', () => {
     it('mail.mhGetSender() - returns sender', () => {
       cy
         .mhGetAllMails()
+        .should('have.length', 1)
         .mhFirst()
         .mhGetSender()
         .should('equal', 'single@example.com');
@@ -74,6 +80,7 @@ describe('MailHog', () => {
     it('mail.mhGetRecipients() - returns recipients', () => {
       cy
       .mhGetAllMails()
+      .should('have.length', 1)
       .mhFirst()
       .mhGetRecipients()
       .should('contain', 'bcc-recipient@example.com');

--- a/test-server/index.html
+++ b/test-server/index.html
@@ -107,18 +107,20 @@
         if (action) {
           setAction(action);
           setStatus('⏳');
-          $.ajax({
-            method: 'POST',
-            url: 'mailer.php',
-            data: {
-              action: action,
-            }
-          }).then(function(response) {
-            setStatus('✅');
-            $('.debug-output').html(response);
-          }).fail(function() {
-            setStatus('🚫');
-          });
+          setTimeout(function () {
+            $.ajax({
+              method: 'POST',
+              url: 'mailer.php',
+              data: {
+                action: action,
+              }
+            }).then(function(response) {
+              setStatus('✅');
+              $('.debug-output').html(response);
+            }).fail(function() {
+              setStatus('🚫');
+            });
+          }, 50) // simulate transport delay
         }
       });
     </script>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,11 +3,11 @@ declare namespace Cypress {
     mhGetJimMode(): Chainable<boolean>;
     mhSetJimMode(enabled: boolean): Chainable<Cypress.Response<any>>;
     mhDeleteAll(): Chainable<Cypress.Response<any>>;
-    mhGetAllMails(limit?: number): Chainable<mailhog.Item[]>;
+    mhGetAllMails(limit?: number, options?: Partial<Timeoutable>): Chainable<mailhog.Item[]>;
     mhFirst(): Chainable<mailhog.Item>;
-    mhGetMailsBySubject(subject: string, limit?: number): Chainable<mailhog.Item[]>;
-    mhGetMailsByRecipient(recipient: string, limit?: number): Chainable<mailhog.Item[]>;
-    mhGetMailsBySender(from: string, limit?: number): Chainable<mailhog.Item[]>;
+    mhGetMailsBySubject(subject: string, limit?: number, options?: Partial<Timeoutable>): Chainable<mailhog.Item[]>;
+    mhGetMailsByRecipient(recipient: string, limit?: number, options?: Partial<Timeoutable>): Chainable<mailhog.Item[]>;
+    mhGetMailsBySender(from: string, limit?: number, options?: Partial<Timeoutable>): Chainable<mailhog.Item[]>;
     mhGetSubject(): Chainable<string>;
     mhGetBody(): Chainable<string>;
     mhGetSender(): Chainable<string>;


### PR DESCRIPTION
This is based on the cypress xpath command https://github.com/cypress-io/cypress-xpath/blob/master/src/index.js, mentioned as best practice for writing custom commands with retries in https://docs.cypress.io/api/cypress-api/custom-commands#See-also.

It should fix https://github.com/SMenigat/cypress-mailhog/issues/11 and might obsoletes the question in https://github.com/SMenigat/cypress-mailhog/issues/17.

If support for Cypress < 12 will be dropped in a future version, this could be solved with Custom Queries https://docs.cypress.io/api/cypress-api/custom-queries. Also, it might be a good idea to add the `limit` parameter to the options object, instead of having multiple parameters.