### PR TITLE
fix: add different way to add auth object

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ If your Mailhog instance uses authentication, add `mailHogAuth` to your cypress 
 }
 ```
 
+or add `mailHogUsername` and `mailHogPassword` in cypress env config
+```json
+{
+  ...
+  "mailHogUsername": "mailhog username",
+  "mailHogPassword": "mailhog password"}
+}
+```
+
 ## Commands
 ### Mail Collection
 #### mhGetAllMails( limit=50, options={timeout=defaultCommandTimeout} ) 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ or add `mailHogUsername` and `mailHogPassword` in cypress env config
 {
   ...
   "mailHogUsername": "mailhog username",
-  "mailHogPassword": "mailhog password"}
+  "mailHogPassword": "mailhog password"
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,14 @@ const mhApiUrl = (path) => {
   return `${basePath}/api${path}`;
 };
 
-const mhAuth = Cypress.env('mailHogAuth') || ''
+let mhAuth = Cypress.env('mailHogAuth') || '';
+if (Cypress.env('mailHogUsername') && Cypress.env('mailHogPassword')) {
+  mhAuth = {
+    'user': Cypress.env('mailHogUsername'),
+    'pass': Cypress.env('mailHogPassword'),
+  };
+}
+
 
 const messages = (limit) => {
     return cy
@@ -55,7 +62,7 @@ Cypress.Commands.add('mhGetJimMode', () => {
       method: 'GET',
       url: mhApiUrl('/v2/jim'),
       failOnStatusCode: false,
-      auth: mhAuth
+      auth: mhAuth,
     })
     .then((response) => {
       return cy.wrap(response.status === 200);
@@ -67,7 +74,7 @@ Cypress.Commands.add('mhSetJimMode', (enabled) => {
     method: enabled ? 'POST' : 'DELETE',
     url: mhApiUrl('/v2/jim'),
     failOnStatusCode: false,
-    auth: mhAuth
+    auth: mhAuth,
   });
 });
 
@@ -78,9 +85,9 @@ Cypress.Commands.add('mhDeleteAll', () => {
   return cy.request({
     method: 'DELETE',
     url: mhApiUrl('/v1/messages'),
-    auth: mhAuth
-  })
-})
+    auth: mhAuth,
+  });
+});
 
 Cypress.Commands.add('mhGetAllMails', (limit=50, options={}) => {
     const filter = (mails) => mails;


### PR DESCRIPTION
## Changes
- This MR support a different way to add a maihog auth object without adding any breaking changes
- Adding JSON env variables in CI pipelines is not a good developer experience and causes a lot of issues.