### PR TITLE
Fix typo in url in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Start docker server.
 docker-compose up
 ```
 
-Open the Testpage in your browser: [http://localhost:8080/cypress-mh-tests/](http://localhost:8080/cypress-mc-tests/)
+Open the Testpage in your browser: [http://localhost:8080/cypress-mh-tests/](http://localhost:8080/cypress-mh-tests/)
 Open MailHog in your browser: [http://localhost:8090/](http://localhost:8090/)
 
 Open the Cypress testclient.


### PR DESCRIPTION
Fixes typo in `README.md`: http://localhost:8080/cypress-mc-tests/ -> http://localhost:8080/cypress-mh-tests/