### PR TITLE
Recipient subject search

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,6 +119,20 @@ Cypress.Commands.add(
     return retryFetchMessages(filter, limit, options);
 });
 
+Cypress.Commands.add(
+  'mhGetMailsByRecipientSubject',
+  (recipient, subject, limit=50, options={}) => {
+  const filter = (mails) => {
+      let mail = mails.filter((mail) =>
+          mail.To.map((recipientObj) =>
+              `${recipientObj.Mailbox}@${recipientObj.Domain}`
+          ).includes(recipient)).filter(mail => mail.Content.Headers.Subject[0] === subject);
+        console.warn(mail);
+        return mail;
+        };
+    return retryFetchMessages(filter, limit, options);
+});
+
 Cypress.Commands.add('mhGetMailsBySender', (from, limit=50, options={}) => {
     const filter = (mails) =>
         mails.filter((mail) => mail.Raw.From === from);

--- a/index.js
+++ b/index.js
@@ -123,12 +123,10 @@ Cypress.Commands.add(
   'mhGetMailsByRecipientSubject',
   (recipient, subject, limit=50, options={}) => {
   const filter = (mails) => {
-      let mail = mails.filter((mail) =>
+      return mails.filter((mail) =>
           mail.To.map((recipientObj) =>
               `${recipientObj.Mailbox}@${recipientObj.Domain}`
           ).includes(recipient)).filter(mail => mail.Content.Headers.Subject[0] === subject);
-        console.warn(mail);
-        return mail;
         };
     return retryFetchMessages(filter, limit, options);
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,6 +9,7 @@ declare namespace Cypress {
     mhGetAllMails(limit?: number, options?: Partial<Timeoutable>): Chainable<mailhog.Item[]>;
     mhFirst(): Chainable<mailhog.Item>;
     mhGetMailsBySubject(subject: string, limit?: number, options?: Partial<Timeoutable>): Chainable<mailhog.Item[]>;
+    mhGetMailsByRecipientSubject(recipient: string, subject: string, limit?: number, options?: Partial<Timeoutable>): Chainable<mailhog.Item[]>;
     mhGetMailsByRecipient(recipient: string, limit?: number, options?: Partial<Timeoutable>): Chainable<mailhog.Item[]>;
     mhGetMailsBySender(from: string, limit?: number, options?: Partial<Timeoutable>): Chainable<mailhog.Item[]>;
     mhGetSubject(): Chainable<string>;


### PR DESCRIPTION
Added new search by both recipient and subject, for the cases in which the recipient gets many emails, but specifically one with a given subject is wanted, which is not the first