### PR TITLE
Trim basePath

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 const mhApiUrl = (path) => {
   const envValue = Cypress.env("mailHogUrl");
   const basePath = envValue ? envValue : Cypress.config("mailHogUrl");
-  return `${basePath}/api${path}`;
+  const trimmedBasePath = basePath.endsWith('/') ? basePath.slice(0, -1) : basePath;
+  return `${trimmedBasePath}/api${path}`;
 };
 
 let mhAuth = Cypress.env("mailHogAuth") || "";


### PR DESCRIPTION
Fixed an issue where the `mhDeleteAll()` didn't work due to trailing / in the url

### Reproduction steps:
1. Use in cypress.config.js:
```
env: {
    mailHogUrl: "http://localhost:8025/"
}
  ```
2. Use in code `mhDeleteAll()`
