### PR TITLE
Use valid spdx license id

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "MailHog"
   ],
   "author": "Samuel Menigat <samuel.menigat@gmail.com>",
-  "license": "mit",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/SMenigat/cypress-mailhog/issues"
   },


### PR DESCRIPTION
We are using [dependency-review-action](https://github.com/actions/dependency-review-action) in our github pipeline to prevent usage of denied licenses.

Right now, the action flags this package because it is using an invalid SPDX license id "mit" rather than "MIT". Here is the list of valid license ids: https://spdx.org/licenses/
<img width="494" alt="image" src="https://github.com/user-attachments/assets/3135f700-a93f-48dc-9bbf-ccf9429644fd">

I've verified that setting the correct license ID in package.json allows the dependency-review-action to correctly identify the license.
<img width="387" alt="image" src="https://github.com/user-attachments/assets/ee889497-6a68-49cb-8a41-8474831d2058">
